### PR TITLE
Update bintray-release to 0.9 to build with gradle 4.6+

### DIFF
--- a/annotation/build.gradle
+++ b/annotation/build.gradle
@@ -18,4 +18,5 @@ publish {
     website = metadata.website
     repository = metadata.repository
     licences = metadata.licences
+    userOrg = metadata.userOrg
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.novoda:bintray-release:0.8.0'
+        classpath 'com.novoda:bintray-release:0.9'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ apply from: "https://raw.githubusercontent.com/maskarade/Android-Orma/master/ver
 buildscript {
     ext.kotlin_version = '1.2.40'
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -17,8 +17,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 24 21:52:59 JST 2018
+#Thu Oct 18 17:11:31 JST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -54,4 +54,5 @@ publish {
     website = metadata.website
     repository = metadata.repository
     licences = metadata.licences
+    userOrg = metadata.userOrg
 }

--- a/metadata.gradle
+++ b/metadata.gradle
@@ -3,6 +3,7 @@ ext {
             groupId   : 'com.github.hisaichi5518.konohana',
             website   : 'https://github.com/hisaichi5518/konohana',
             repository: 'git@github.com:hisaichi5518/konohana.git',
-            licences  : ['Apache-2.0']
+            licences  : ['Apache-2.0'],
+            userOrg   : 'hisaichi5518'
     ]
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -33,4 +33,5 @@ publish {
     website = metadata.website
     repository = metadata.repository
     licences = metadata.licences
+    userOrg = metadata.userOrg
 }


### PR DESCRIPTION
AndroidX migration needs gradle 4.6+, but can not build with gradle 4.6+ because of bintray-release.
So, I updated bintray-release to 0.9 and gradle to 4.6.

See: https://github.com/novoda/bintray-release/releases